### PR TITLE
Add list format

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,9 +22,16 @@ jobs:
       - run: npm ci
       - run: npm run build
       - uses: ./
-        id: result
         with:
+          path: __test-raw.txt
           query: 'label:integration-test'
           token: ${{ github.token }}
-      - run: "grep -q 'https://github.com/lee-dohm/select-matching-issues/issues/6' __matching-issues.txt || exit 1"
-        name: 'Fail unless file contains the expected URL'
+      - name: 'Fail unless raw file contains the expected URL'
+        run: "grep -q 'https://github.com/lee-dohm/select-matching-issues/issues/6' __test-raw.txt || exit 1"
+      - uses: ./
+        with:
+          path: __test-list.txt
+          query: 'label:integration-test'
+          token: ${{ github.token }}
+      - name: 'Fail unless list file contains the expected line'
+        run: "grep -q '* [Test issue](https://github.com/lee-dohm/select-matching-issues/issues/6)' __test-list.txt || exit 1"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,7 @@ jobs:
         run: "grep -q 'https://github.com/lee-dohm/select-matching-issues/issues/6' __test-raw.txt || exit 1"
       - uses: ./
         with:
+          format: list
           path: __test-list.txt
           query: 'label:integration-test'
           token: ${{ github.token }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,6 +26,7 @@ jobs:
           path: __test-raw.txt
           query: 'label:integration-test'
           token: ${{ github.token }}
+      - run: 'cat __test-raw.txt'
       - name: 'Fail unless raw file contains the expected URL'
         run: "grep -q 'https://github.com/lee-dohm/select-matching-issues/issues/6' __test-raw.txt || exit 1"
       - uses: ./
@@ -33,5 +34,6 @@ jobs:
           path: __test-list.txt
           query: 'label:integration-test'
           token: ${{ github.token }}
+      - run: 'cat __test-list.txt'
       - name: 'Fail unless list file contains the expected line'
         run: "grep -q -F '* [Test issue](https://github.com/lee-dohm/select-matching-issues/issues/6)' __test-list.txt || exit 1"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,4 +34,4 @@ jobs:
           query: 'label:integration-test'
           token: ${{ github.token }}
       - name: 'Fail unless list file contains the expected line'
-        run: "grep -q '* [Test issue](https://github.com/lee-dohm/select-matching-issues/issues/6)' __test-list.txt || exit 1"
+        run: "grep -q -F '* [Test issue](https://github.com/lee-dohm/select-matching-issues/issues/6)' __test-list.txt || exit 1"

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,3 +1,4 @@
 printWidth: 100
 semi: false
 singleQuote: true
+trailingComma: none

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
         id: bugs
         uses: lee-dohm/select-matching-issues@v1
         with:
-          query: "label:bug"
+          query: 'label:bug'
           token: ${{ github.token }}
       - name: Close found issues
         run: cat ${{ steps.bugs.outputs.path }} | xargs gh issue close
@@ -55,15 +55,15 @@ jobs:
         uses: lee-dohm/select-matching-issues@v1
         with:
           format: list
-          query: "label:out-of-office"
+          query: 'label:out-of-office'
           token: ${{ github.token }}
 ```
 
 Example output:
 
 ```markdown
-* [@octocat OoO Jan 1 through Jan 31](https://github.com/octocat/spoon-knife/issues/1)
-* [@lee-dohm OoO Feb 1 through Feb 28](https://github.com/octocat/spoon-knife/issues/3)
+- [@octocat OoO Jan 1 through Jan 31](https://github.com/octocat/spoon-knife/issues/1)
+- [@lee-dohm OoO Feb 1 through Feb 28](https://github.com/octocat/spoon-knife/issues/3)
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -4,9 +4,19 @@ A GitHub Action to select issues matching a query.
 
 ## Use
 
+By specifying the `query` and `token` to use, you can output the list of matching issues. The list of matching issues is stored in a file because the output could potentially be quite large. The location of the file is written to the `path` output.
+
+### Setting the file location yourself
+
+By specifying the `path` input, you can set the path where the output is stored. Whatever is specified as the `path` input is also returned as the `path` output.
+
+### Configuring the output format
+
+There are two output formats: `raw` and `list`. The default format is `raw`. The `raw` format writes the full URL of each matching Issue, one Issue per line. The `list` format writes the matching Issues in a Markdown unordered list, with each item being a link using the title of the Issue as the link text and the URL being the link target.
+
 ### Examples
 
-Closing a list of matching issues:
+#### Closing a list of matching issues
 
 ```yaml
 jobs:
@@ -18,10 +28,42 @@ jobs:
         id: bugs
         uses: lee-dohm/select-matching-issues@v1
         with:
-          query: 'label:bug'
+          query: "label:bug"
           token: ${{ github.token }}
       - name: Close found issues
         run: cat ${{ steps.bugs.outputs.path }} | xargs gh issue close
+```
+
+Example output:
+
+```markdown
+https://github.com/octocat/spoon-knife/issues/1
+https://github.com/octocat/spoon-knife/issues/3
+https://github.com/octocat/spoon-knife/issues/9
+```
+
+#### Create a Markdown list of issues labeled `out-of-office`
+
+```yaml
+jobs:
+  markdownList:
+    name: List issues labeled "out-of-office"
+    runs-on: ubuntu-latest
+    steps:
+      - name: List out-of-office issues
+        id: ooo_list
+        uses: lee-dohm/select-matching-issues@v1
+        with:
+          format: list
+          query: "label:out-of-office"
+          token: ${{ github.token }}
+```
+
+Example output:
+
+```markdown
+* [@octocat OoO Jan 1 through Jan 31](https://github.com/octocat/spoon-knife/issues/1)
+* [@lee-dohm OoO Feb 1 through Feb 28](https://github.com/octocat/spoon-knife/issues/3)
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,9 @@
 name: select-matching-issues
 description: Selects issues matching a query
 inputs:
+  format:
+    default: raw
+    description: Format to use when outputting the list of issues to the file
   path:
     default: __matching-issues.txt
     description: Path to store the resulting list of issues

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,0 +1,21 @@
+import { Issue } from './github'
+
+/**
+ * Formats the issues into a Markdown unordered list of Issue links, one per line.
+ *
+ * The Issue's title is used as the link text and the Issue's URL is used as the link target.
+ *
+ * @param issues List of issues to format
+ */
+export function list(issues: Issue[]): string {
+  return issues.map((issue) => `* [${issue.title}](${issue.url})`).join('\n')
+}
+
+/**
+ * Formats the issues into a raw list of Issue URLs, one per line of text.
+ *
+ * @param issues List of issues to format
+ */
+export function raw(issues: Issue[]): string {
+  return issues.map((issue) => issue.url).join('\n')
+}

--- a/src/github.ts
+++ b/src/github.ts
@@ -11,6 +11,14 @@ interface IssueUrl {
 }
 
 /**
+ * An object containing information about a GitHub Issue.
+ */
+export interface Issue {
+  title: string
+  url: string
+}
+
+/**
  * An object containing a repository name and owner.
  */
 interface NameWithOwner {
@@ -29,6 +37,7 @@ query($searchQuery: String!) {
   search(first: 100, query: $searchQuery, type: ISSUE) {
     nodes {
       ... on Issue {
+        title
         url
       }
     }
@@ -46,7 +55,7 @@ export function formatNameWithOwner({ owner, repo }: NameWithOwner): string {
 }
 
 /**
- * Gets the list of issue URLs that match the query.
+ * Gets the list of Issues that match the query.
  *
  * Takes the `searchQuery`, includes a specifier to restrict the query to the current repo,
  * and inserts it into the GraphQL search query template.
@@ -54,7 +63,7 @@ export function formatNameWithOwner({ owner, repo }: NameWithOwner): string {
  * @param token Token to use to execute the search
  * @param searchQuery Search query to execute
  */
-export async function getIssueUrls(token: string, searchQuery: string): Promise<string[]> {
+export async function getMatchingIssues(token: string, searchQuery: string): Promise<Issue[]> {
   const client = github.getOctokit(token)
   const context = github.context
   const queryText = `repo:${formatNameWithOwner(context.repo)} ${searchQuery}`
@@ -66,7 +75,7 @@ export async function getIssueUrls(token: string, searchQuery: string): Promise<
   core.debug(`Results: ${JSON.stringify(results, null, 2)}`)
 
   if (results) {
-    return results.search.nodes.map((issue: IssueUrl) => issue.url)
+    return results.search.nodes.map((issue: Issue) => issue)
   } else {
     return []
   }

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -1,0 +1,50 @@
+import * as format from '../src/format'
+
+const issues = [
+  {
+    title: 'Foo',
+    url: 'https://github.com/test-owner/test-repo/issues/1219'
+  },
+  {
+    title: 'Bar',
+    url: 'https://github.com/test-owner/test-repo/issues/1213'
+  },
+  {
+    title: 'Baz',
+    url: 'https://github.com/test-owner/test-repo/issues/1207'
+  },
+  {
+    title: 'Quux',
+    url: 'https://github.com/test-owner/test-repo/issues/1198'
+  }
+]
+
+describe('list', () => {
+  it('returns a list of Issue links', () => {
+    const text = format.list(issues)
+
+    expect(text).toBe(`* [Foo](https://github.com/test-owner/test-repo/issues/1219)
+* [Bar](https://github.com/test-owner/test-repo/issues/1213)
+* [Baz](https://github.com/test-owner/test-repo/issues/1207)
+* [Quux](https://github.com/test-owner/test-repo/issues/1198)`)
+  })
+
+  it('returns an empty string when given an empty list', () => {
+    expect(format.list([])).toBe('')
+  })
+})
+
+describe('raw', () => {
+  it('returns a list of Issue URLs', () => {
+    const text = format.raw(issues)
+
+    expect(text).toBe(`https://github.com/test-owner/test-repo/issues/1219
+https://github.com/test-owner/test-repo/issues/1213
+https://github.com/test-owner/test-repo/issues/1207
+https://github.com/test-owner/test-repo/issues/1198`)
+  })
+
+  it('returns an empty string when given an empty list', () => {
+    expect(format.raw([])).toBe('')
+  })
+})


### PR DESCRIPTION
Adds the ability to format the output of the matching issues as a Markdown list formatted as such:

```markdown
* [First issue](https://github.com/test-user/test-repo/issues/1)
* [Second issue](https://github.com/test-user/test-repo/issues/2)
```
