### PR TITLE
Use hyphens for unordered Markdown list items

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,4 +37,4 @@ jobs:
           token: ${{ github.token }}
       - run: 'cat __test-list.txt'
       - name: 'Fail unless list file contains the expected line'
-        run: "grep -q -F '- [Test issue](https://github.com/lee-dohm/select-matching-issues/issues/6)' __test-list.txt || exit 1"
+        run: "grep -q -F \"- [Test issue](https://github.com/lee-dohm/select-matching-issues/issues/6)\" __test-list.txt || exit 1"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,4 +37,4 @@ jobs:
           token: ${{ github.token }}
       - run: 'cat __test-list.txt'
       - name: 'Fail unless list file contains the expected line'
-        run: "grep -q -F '* [Test issue](https://github.com/lee-dohm/select-matching-issues/issues/6)' __test-list.txt || exit 1"
+        run: "grep -q -F '- [Test issue](https://github.com/lee-dohm/select-matching-issues/issues/6)' __test-list.txt || exit 1"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,4 +37,4 @@ jobs:
           token: ${{ github.token }}
       - run: 'cat __test-list.txt'
       - name: 'Fail unless list file contains the expected line'
-        run: 'grep -q -F "\- [Test issue](https://github.com/lee-dohm/select-matching-issues/issues/6)" __test-list.txt || exit 1'
+        run: 'grep -q -F "[Test issue](https://github.com/lee-dohm/select-matching-issues/issues/6)" __test-list.txt || exit 1'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,4 +37,4 @@ jobs:
           token: ${{ github.token }}
       - run: 'cat __test-list.txt'
       - name: 'Fail unless list file contains the expected line'
-        run: 'grep -q -F "- [Test issue](https://github.com/lee-dohm/select-matching-issues/issues/6)" __test-list.txt || exit 1'
+        run: 'grep -q -F "\- [Test issue](https://github.com/lee-dohm/select-matching-issues/issues/6)" __test-list.txt || exit 1'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,4 +37,4 @@ jobs:
           token: ${{ github.token }}
       - run: 'cat __test-list.txt'
       - name: 'Fail unless list file contains the expected line'
-        run: "grep -q -F \"- [Test issue](https://github.com/lee-dohm/select-matching-issues/issues/6)\" __test-list.txt || exit 1"
+        run: 'grep -q -F "- [Test issue](https://github.com/lee-dohm/select-matching-issues/issues/6)" __test-list.txt || exit 1'

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A GitHub Action to select issues matching a query",
   "main": "dist/index.js",
   "scripts": {
-    "build": "npx ncc build --source-map ./src/main.ts",
+    "build": "npx ncc build ./src/main.ts",
     "ci": "npm run format-check && npm test",
     "format": "prettier --write **/*.ts **/*.md **/*.yaml **/*.yml",
     "format-check": "prettier --check **/*.ts **/*.md **/*.yaml **/*.yml",

--- a/src/format.ts
+++ b/src/format.ts
@@ -8,7 +8,7 @@ import { Issue } from './github'
  * @param issues List of issues to format
  */
 export function list(issues: Issue[]): string {
-  return issues.map((issue) => `* [${issue.title}](${issue.url})`).join('\n')
+  return issues.map((issue) => `- [${issue.title}](${issue.url})`).join('\n')
 }
 
 /**

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -23,10 +23,10 @@ describe('list', () => {
   it('returns a list of Issue links', () => {
     const text = format.list(issues)
 
-    expect(text).toBe(`* [Foo](https://github.com/test-owner/test-repo/issues/1219)
-* [Bar](https://github.com/test-owner/test-repo/issues/1213)
-* [Baz](https://github.com/test-owner/test-repo/issues/1207)
-* [Quux](https://github.com/test-owner/test-repo/issues/1198)`)
+    expect(text).toBe(`- [Foo](https://github.com/test-owner/test-repo/issues/1219)
+- [Bar](https://github.com/test-owner/test-repo/issues/1213)
+- [Baz](https://github.com/test-owner/test-repo/issues/1207)
+- [Quux](https://github.com/test-owner/test-repo/issues/1198)`)
   })
 
   it('returns an empty string when given an empty list', () => {


### PR DESCRIPTION
This way the README documentation will match the eventual output.