### PR TITLE
feat: Support ndjson format

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -22,6 +22,15 @@ export function raw(issues: Issue[]): string {
 }
 
 /**
+ * Formats the issues into a NDJSON format, each line is a JSON object.
+ *
+ * @param issues List of issues to format
+ */
+ export function ndjson(issues: Issue[]): string {
+  return issues.map((issue) => JSON.stringify(issue)).join('\n')
+ }
+
+/**
  * Writes the list of issues to a string in the requested format.
  *
  * @param issues List of issues to format
@@ -34,6 +43,9 @@ export function write(issues: Issue[], format: OutputFormat): string {
 
     case OutputFormat.RAW:
       return raw(issues)
+
+    case OutputFormat.NDJSON:
+      return ndjson(issues)
 
     default:
       throw new Error(`Invalid output format: ${format}`)

--- a/src/output-format.ts
+++ b/src/output-format.ts
@@ -7,5 +7,8 @@ export enum OutputFormat {
   LIST = 'list',
 
   /** Outputs a raw list of URLs, one per line */
-  RAW = 'raw'
+  RAW = 'raw',
+
+  /** Outputs a NDJSON data **/
+  NDJSON = 'ndjson'
 }


### PR DESCRIPTION
I wanna generate a changelog by github issues, it need a full infomation about the issues data, so I can category the issues by its fields.

Currently we have `raw` and `list` formats in select-matching-issues, how about adding a NDJSON format, so we can process the data in a seperated action later.

Thank you in advance!

